### PR TITLE
Implement CI to build release assets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,8 +93,6 @@ jobs:
       - name: Setup Cygwin
         if: "contains(matrix.shell, 'cygwin')"
         uses: egor-tensin/setup-cygwin@v4
-        with:
-          platform: x64
 
       - name: helm plugin install
         run: helm plugin install .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,9 @@ jobs:
 
       - name: Verify installation
         run: |
-          mkdir -p helmhome
-          make install HELM_HOME=helmhome
-          helmhome/plugins/helm-set-status/bin/helm-set-status version
+          mkdir -p helmplugindir
+          make install HELM_3_PLUGINS=helmplugindir
+          helmplugindir/helm-set-status/bin/helm-set-status version
 
   helm-install:
     name: helm install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,100 @@
+---
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: "Build & Test"
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install dependencies
+        run: make bootstrap
+
+      - name: Run unit tests
+        run: make test
+
+      - name: Verify installation
+        run: |
+          mkdir -p helmhome
+          make install HELM_HOME=helmhome
+          helmhome/plugins/helm-set-status/bin/helm-set-status version
+
+  helm-install:
+    name: helm install
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    needs: [build]
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        shell: [ default ]
+        experimental: [ false ]
+        helm-version: [ v3.17.2, v3.16.4 ]
+        include:
+          - os: windows-latest
+            shell: wsl
+            experimental: false
+            helm-version: v3.17.2
+          - os: windows-latest
+            shell: cygwin
+            experimental: false
+            helm-version: v3.17.2
+          - os: ubuntu-latest
+            container: alpine
+            shell: sh
+            experimental: false
+            helm-version: v3.17.2
+          - os: windows-latest
+            shell: wsl
+            experimental: false
+            helm-version: v3.16.4
+          - os: windows-latest
+            shell: cygwin
+            experimental: false
+            helm-version: v3.16.4
+          - os: ubuntu-latest
+            container: alpine
+            shell: sh
+            experimental: false
+            helm-version: v3.16.4
+
+    steps:
+      - name: Disable autocrlf
+        if: "contains(matrix.os, 'windows-latest')"
+        run: |-
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ matrix.helm-version }}
+
+      - name: Setup WSL
+        if: "contains(matrix.shell, 'wsl')"
+        uses: Vampire/setup-wsl@v5
+
+      - name: Setup Cygwin
+        if: "contains(matrix.shell, 'cygwin')"
+        uses: egor-tensin/setup-cygwin@v4
+        with:
+          platform: x64
+
+      - name: helm plugin install
+        run: helm plugin install .

--- a/.github/workflows/lint-sh.yaml
+++ b/.github/workflows/lint-sh.yaml
@@ -3,14 +3,14 @@ name: Lint sh
 on:
   push:
     branches: [main]
-    paths: ['install-binary.sh']
+    paths: ['scripts/install_plugin.sh']
   pull_request:
     branches: [main]
-    paths: ['install-binary.sh']
+    paths: ['scripts/install_plugin.sh']
 
 jobs:
   lint-sh:
-    name: Lint install-binary.sh
+    name: Lint scripts/install_plugin.sh
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     continue-on-error: true

--- a/.github/workflows/lint-sh.yaml
+++ b/.github/workflows/lint-sh.yaml
@@ -1,0 +1,22 @@
+name: Lint sh
+
+on:
+  push:
+    branches: [master]
+    paths: ['install-binary.sh']
+  pull_request:
+    branches: [master]
+    paths: ['install-binary.sh']
+
+jobs:
+  lint-sh:
+    name: Lint install-binary.sh
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: luizm/action-sh-checker@v0.9.0
+        with:
+          sh_checker_exclude: 'scripts'
+          sh_checker_checkbashisms_enable: true

--- a/.github/workflows/lint-sh.yaml
+++ b/.github/workflows/lint-sh.yaml
@@ -18,5 +18,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: luizm/action-sh-checker@v0.9.0
         with:
-          sh_checker_exclude: 'scripts/verify-* scripts/update-* scripts/release.sh'
           sh_checker_checkbashisms_enable: true

--- a/.github/workflows/lint-sh.yaml
+++ b/.github/workflows/lint-sh.yaml
@@ -13,7 +13,6 @@ jobs:
     name: Lint scripts/install_plugin.sh
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: luizm/action-sh-checker@v0.9.0

--- a/.github/workflows/lint-sh.yaml
+++ b/.github/workflows/lint-sh.yaml
@@ -18,5 +18,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: luizm/action-sh-checker@v0.9.0
         with:
-          sh_checker_exclude: 'scripts'
+          sh_checker_exclude: 'scripts/verify-* scripts/update-* scripts/release.sh'
           sh_checker_checkbashisms_enable: true

--- a/.github/workflows/lint-sh.yaml
+++ b/.github/workflows/lint-sh.yaml
@@ -2,10 +2,10 @@ name: Lint sh
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths: ['install-binary.sh']
   pull_request:
-    branches: [master]
+    branches: [main]
     paths: ['install-binary.sh']
 
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,10 +3,10 @@ name: Lint
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore: [ '**.md' ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore: [ '**.md' ]
 
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,24 @@
+---
+name: Lint
+
+on:
+  push:
+    branches: [ master ]
+    paths-ignore: [ '**.md' ]
+  pull_request:
+    branches: [ master ]
+    paths-ignore: [ '**.md' ]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.0.1 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: echo "flags=--snapshot" >> $GITHUB_ENV
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v1'
+          args: release --clean ${{ env.flags }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /bin
 /dist
+/build
+/cover.out
+docker-run-release-cache/
+/release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,40 @@
+# To test this manually, run:
+#  go install github.com/goreleaser/goreleaser@latest
+#  goreleaser --snapshot --clean
+#  for f in dist/helm-set-status*.tgz; do echo Testing $f...; tar tzvf $f; done
+project_name: helm-set-status
+builds:
+  - id: default
+    main: ./cmd/helm-set-status
+    binary: bin/helm-set-status
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -X main.version=${VERSION}
+    goos:
+      - freebsd
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: default
+    builds:
+    - default
+    format: tgz
+    name_template: '{{ .ProjectName }}-{{ if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}-{{ .Arch }}'
+    wrap_in_directory: helm-set-status
+    files:
+    - README.md
+    - plugin.yaml
+    - LICENSE
+changelog:
+  use: github-native
+
+release:
+  prerelease: auto

--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,74 @@
+HELM_HOME ?= $(shell helm home)
 BINARY := helm-set-status
-
-HELM_PLUGIN := $(shell helm env | sed -n -e 's/HELM_PLUGINS=[ "]*\([^"]*\).*/\1/p')
-HELM_PLUGIN_PATH ?= $(HELM_PLUGIN)/$(BINARY)
-
 VERSION := $(shell sed -n -e 's/version:[ "]*\([^"]*\).*/\1/p' plugin.yaml)
-LDFLAGS := "-X main.version=${VERSION} -extldflags -static -w -s"
-TAGS := "static_build netcgo osusergo"
-OS_PLATFORM := $(shell uname -sp | tr '[:upper:] ' '[:lower:]-' | sed 's/x86_64/amd64/')
 
-GO111MODULE = on
-CGO_ENABLED = 1
+HELM_3_PLUGINS := $(shell helm env HELM_PLUGINS)
+LDFLAGS := -X main.version=${VERSION}
+
+GO ?= go
+
+.PHONY: format
+format:
+	test -z "$$(find . -type f -o -name '*.go' -exec gofmt -d {} + | tee /dev/stderr)" || \
+	test -z "$$(find . -type f -o -name '*.go' -exec gofmt -w {} + | tee /dev/stderr)"
 
 .PHONY: install
 install: build
-	[ -e $(HELM_PLUGIN_PATH) ] || mkdir -p $(HELM_PLUGIN_PATH)
-	cp bin/$(BINARY) $(HELM_PLUGIN_PATH)/
-	cp plugin.yaml $(HELM_PLUGIN_PATH)/
-
-.PHONY: package
-package: build
-	[ -e dist ] || mkdir -p dist
-	tar -czvf dist/$(BINARY)-$(OS_PLATFORM).tgz -C bin/ helm-set-status
-
-.PHONY: build
-build:
-	go build -o bin/$(BINARY) -tags $(TAGS) -ldflags $(LDFLAGS) ./cmd/helm-set-status
+	mkdir -p $(HELM_3_PLUGINS)/helm-set-status/bin
+	cp bin/$(BINARY) $(HELM_3_PLUGINS)/helm-set-status/bin
+	cp plugin.yaml $(HELM_3_PLUGINS)/helm-set-status/
 
 .PHONY: lint
 lint:
-	golangci-lint run -v ./pkg/... ./cmd/...
+	scripts/update-gofmt.sh
+	scripts/verify-gofmt.sh
+	scripts/verify-govet.sh
+	scripts/verify-staticcheck.sh
+
+.PHONY: build
+build: lint
+	mkdir -p bin/
+	go build -v -o bin/$(BINARY) -ldflags="$(LDFLAGS)" ./cmd/helm-set-status
 
 .PHONY: test
 test:
-	go test -v ./cmd/... ./pkg/...
+	go test -v ./... -coverprofile cover.out -race
+	go tool cover -func cover.out
+
+.PHONY: bootstrap
+bootstrap:
+	go mod download
+	command -v staticcheck || go install honnef.co/go/tools/cmd/staticcheck@latest
+
+.PHONY: dist
+dist: export COPYFILE_DISABLE=1 #teach OSX tar to not put ._* files in tar archive
+dist: export CGO_ENABLED=0
+dist:
+	rm -rf build/$(BINARY)/* release/*
+	mkdir -p build/$(BINARY)/bin release/
+	cp README.md LICENSE plugin.yaml build/$(BINARY)
+	GOOS=linux GOARCH=amd64 $(GO) build -o build/$(BINARY)/bin/$(BINARY) -trimpath -ldflags="$(LDFLAGS)" ./cmd/helm-set-status
+	tar -C build/ -zcvf $(CURDIR)/release/helm-set-status-linux-amd64.tgz $(BINARY)/
+	GOOS=linux GOARCH=arm64 $(GO) build -o build/$(BINARY)/bin/$(BINARY) -trimpath -ldflags="$(LDFLAGS)" ./cmd/helm-set-status
+	tar -C build/ -zcvf $(CURDIR)/release/helm-set-status-linux-arm64.tgz $(BINARY)/
+	GOOS=freebsd GOARCH=amd64 $(GO) build -o build/$(BINARY)/bin/$(BINARY) -trimpath -ldflags="$(LDFLAGS)" ./cmd/helm-set-status
+	tar -C build/ -zcvf $(CURDIR)/release/helm-set-status-freebsd-amd64.tgz $(BINARY)/
+	GOOS=darwin GOARCH=amd64 $(GO) build -o build/$(BINARY)/bin/$(BINARY) -trimpath -ldflags="$(LDFLAGS)" ./cmd/helm-set-status
+	tar -C build/ -zcvf $(CURDIR)/release/helm-set-status-macos-amd64.tgz $(BINARY)/
+	GOOS=darwin GOARCH=arm64 $(GO) build -o build/$(BINARY)/bin/$(BINARY) -trimpath -ldflags="$(LDFLAGS)" ./cmd/helm-set-status
+	tar -C build/ -zcvf $(CURDIR)/release/helm-set-status-macos-arm64.tgz $(BINARY)/
+	rm build/$(BINARY)/bin/$(BINARY)
+	GOOS=windows GOARCH=amd64 $(GO) build -o build/$(BINARY)/bin/$(BINARY).exe -trimpath -ldflags="$(LDFLAGS)" ./cmd/helm-set-status
+	tar -C build/ -zcvf $(CURDIR)/release/helm-set-status-windows-amd64.tgz $(BINARY)/
+	rm -rf build/
+
+# Manual release process - CI uses goreleaser to do multiarch compilation and release
+.PHONY: release
+release: lint dist
+	scripts/release.sh v$(VERSION)
+
+# Test for the plugin installation with `helm plugin install -v THIS_BRANCH` works
+# Useful for verifying modified `install-binary.sh` still works against various environments
+.PHONY: test-plugin-installation
+test-plugin-installation:
+	docker build -f testdata/Dockerfile.install .

--- a/cmd/helm-set-status/main.go
+++ b/cmd/helm-set-status/main.go
@@ -75,6 +75,7 @@ func SetStatus(helmOptions common.HelmOptions, kubeConfig common.KubeConfig) err
 
 func main() {
 	setStatusCmd := NewRootCmd(os.Stdout, os.Args[1:])
+	setStatusCmd.AddCommand(newVersionCmd())
 
 	if err := setStatusCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/helm-set-status/main.go
+++ b/cmd/helm-set-status/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 
@@ -20,7 +21,10 @@ func NewRootCmd(out io.Writer, args []string) *cobra.Command {
 		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				cmd.Help()
+				err := cmd.Help()
+				if err != nil {
+					fmt.Println("Unable to print help information")
+				}
 				os.Exit(1)
 			} else if len(args) != 2 {
 				return errors.New("release and status must be specified")
@@ -30,7 +34,10 @@ func NewRootCmd(out io.Writer, args []string) *cobra.Command {
 		RunE: runSetStatus,
 	}
 	flags := cmd.PersistentFlags()
-	flags.Parse(args)
+	err := flags.Parse(args)
+	if err != nil {
+		fmt.Println("Failed to parse arguments!")
+	}
 	settings = new(EnvSettings)
 	settings.AddFlags(flags)
 

--- a/cmd/helm-set-status/version.go
+++ b/cmd/helm-set-status/version.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Version identifier populated via the CI/CD process.
+var version = "HEAD"
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Show version of the helm diff plugin",
+		Run: func(*cobra.Command, []string) {
+			fmt.Println(version)
+		},
+	}
+}

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 ---
 name: "set-status"
-version: "0.1.0"
+version: "0.3.1"
 usage: "helm set-status <RELEASE_NAME>"
 description: |-
   Manually set the status of a helm release

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,6 +5,7 @@ usage: "helm set-status <RELEASE_NAME>"
 description: |-
   Manually set the status of a helm release
 ignoreFlags: false
-command: "$HELM_PLUGIN_DIR/helm-set-status"
+command: "$HELM_PLUGIN_DIR/bin/helm-set-status"
 hooks:
   install: "cd $HELM_PLUGIN_DIR; scripts/install_plugin.sh"
+  update: "cd $HELM_PLUGIN_DIR; scripts/install_plugin.sh -u"

--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -1,21 +1,157 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
-set -e
+# Shamelessly copied from https://github.com/technosophos/helm-template
 
-plugin_version=$(sed -n -e 's/version:[ "]*\([^"]*\).*/\1/p' ${HELM_PLUGIN_DIR}/plugin.yaml)
-SET_STATUS_VERSION=${SET_STATUS_VERSION:-$plugin_version}
+PROJECT_NAME="helm-set-status"
+PROJECT_GH="daviddob/helm-set-status-plugin"
+export GREP_COLOR="never"
 
-os_arch=$(uname -sp | tr '[:upper:] ' '[:lower:]-' | sed 's/x86_64/amd64/')
-release_file="helm-set-status-${os_arch}.tgz"
-url="https://github.com/k3s-io/helm-set-status/releases/download/v${SET_STATUS_VERSION}/${release_file}"
+# Convert HELM_BIN and HELM_PLUGIN_DIR to unix if cygpath is
+# available. This is the case when using MSYS2 or Cygwin
+# on Windows where helm returns a Windows path but we
+# need a Unix path
 
-mkdir -p ${dir}
-
-if command -v wget; then
-  wget -qO - ${url} | tar -zxvC ${HELM_PLUGIN_DIR}
-elif command -v curl; then
-  curl -sL ${url} | tar -zxvC ${HELM_PLUGIN_DIR}
-else
-  echo "Error: could not find wget or curl binary"
-  exit 1
+if command -v cygpath >/dev/null 2>&1; then
+  HELM_BIN="$(cygpath -u "${HELM_BIN}")"
+  HELM_PLUGIN_DIR="$(cygpath -u "${HELM_PLUGIN_DIR}")"
 fi
+
+[ -z "$HELM_BIN" ] && HELM_BIN=$(command -v helm)
+
+[ -z "$HELM_HOME" ] && HELM_HOME=$(helm env | grep 'HELM_DATA_HOME' | cut -d '=' -f2 | tr -d '"')
+
+mkdir -p "$HELM_HOME"
+
+: "${HELM_PLUGIN_DIR:="$HELM_HOME/plugins/$PROJECT_NAME"}"
+
+if [ "$SKIP_BIN_INSTALL" = "1" ]; then
+  echo "Skipping binary install"
+  exit
+fi
+
+# which mode is the common installer script running in
+SCRIPT_MODE="install"
+if [ "$1" = "-u" ]; then
+  SCRIPT_MODE="update"
+fi
+
+# initArch discovers the architecture for this system.
+initArch() {
+  ARCH=$(uname -m)
+  case $ARCH in
+  armv5*) ARCH="armv5" ;;
+  armv6*) ARCH="armv6" ;;
+  armv7*) ARCH="armv7" ;;
+  aarch64) ARCH="arm64" ;;
+  x86) ARCH="386" ;;
+  x86_64) ARCH="amd64" ;;
+  i686) ARCH="386" ;;
+  i386) ARCH="386" ;;
+  esac
+}
+
+# initOS discovers the operating system for this system.
+initOS() {
+  OS=$(uname -s)
+
+  case "$OS" in
+  Windows_NT) OS='windows' ;;
+  # Msys support
+  MSYS*) OS='windows' ;;
+  # Minimalist GNU for Windows
+  MINGW*) OS='windows' ;;
+  CYGWIN*) OS='windows' ;;
+  Darwin) OS='macos' ;;
+  Linux) OS='linux' ;;
+  esac
+}
+
+# verifySupported checks that the os/arch combination is supported for
+# binary builds.
+verifySupported() {
+  supported="linux-amd64\nlinux-arm64\nfreebsd-amd64\nmacos-amd64\nmacos-arm64\nwindows-amd64"
+  if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
+    echo "No prebuild binary for ${OS}-${ARCH}."
+    exit 1
+  fi
+
+  if
+    ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1
+  then
+    echo "Either curl or wget is required"
+    exit 1
+  fi
+}
+
+# getDownloadURL checks the latest available version.
+getDownloadURL() {
+  version=$(git -C "$HELM_PLUGIN_DIR" describe --tags --exact-match 2>/dev/null || :)
+  if [ "$SCRIPT_MODE" = "install" ] && [ -n "$version" ]; then
+    DOWNLOAD_URL="https://github.com/$PROJECT_GH/releases/download/$version/$PROJECT_NAME-$OS-$ARCH.tgz"
+  else
+    DOWNLOAD_URL="https://github.com/$PROJECT_GH/releases/latest/download/$PROJECT_NAME-$OS-$ARCH.tgz"
+  fi
+}
+
+# Temporary dir
+mkTempDir() {
+  HELM_TMP="$(mktemp -d -t "${PROJECT_NAME}-XXXXXX")"
+}
+rmTempDir() {
+  if [ -d "${HELM_TMP:-/tmp/helm-set-status-tmp}" ]; then
+    rm -rf "${HELM_TMP:-/tmp/helm-set-status-tmp}"
+  fi
+}
+
+# downloadFile downloads the latest binary package and also the checksum
+# for that binary.
+downloadFile() {
+  PLUGIN_TMP_FILE="${HELM_TMP}/${PROJECT_NAME}.tgz"
+  echo "Downloading $DOWNLOAD_URL"
+  if
+    command -v curl >/dev/null 2>&1
+  then
+    curl -sSf -L "$DOWNLOAD_URL" >"$PLUGIN_TMP_FILE"
+  elif
+    command -v wget >/dev/null 2>&1
+  then
+    wget -q -O - "$DOWNLOAD_URL" >"$PLUGIN_TMP_FILE"
+  fi
+}
+
+# installFile verifies the SHA256 for the file, then unpacks and
+# installs it.
+installFile() {
+  tar xzf "$PLUGIN_TMP_FILE" -C "$HELM_TMP"
+  HELM_TMP_BIN="$HELM_TMP/$PROJECT_NAME/bin/$PROJECT_NAME"
+  if [ "${OS}" = "windows" ]; then
+    HELM_TMP_BIN="$HELM_TMP_BIN.exe"
+  fi
+  echo "Preparing to install into ${HELM_PLUGIN_DIR}"
+  mkdir -p "$HELM_PLUGIN_DIR/bin"
+  cp "$HELM_TMP_BIN" "$HELM_PLUGIN_DIR/bin"
+}
+
+# exit_trap is executed if on exit (error or not).
+exit_trap() {
+  result=$?
+  rmTempDir
+  if [ "$result" != "0" ]; then
+    echo "Failed to install $PROJECT_NAME"
+    printf "\tFor support, go to https://github.com/${PROJECT_GH}.\n"
+  fi
+  exit $result
+}
+
+# Execution
+
+#Stop execution on any error
+trap "exit_trap" EXIT
+set -e
+initArch
+initOS
+verifySupported
+getDownloadURL
+mkTempDir
+downloadFile
+installFile

--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -93,7 +93,7 @@ getDownloadURL() {
   fi
 }
 
-# Temporary dir
+# Temporary dir.
 mkTempDir() {
   HELM_TMP="$(mktemp -d -t "${PROJECT_NAME}-XXXXXX")"
 }

--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -3,7 +3,7 @@
 # Shamelessly copied from https://github.com/technosophos/helm-template
 
 PROJECT_NAME="helm-set-status"
-PROJECT_GH="daviddob/helm-set-status-plugin"
+PROJECT_GH="daviddob/helm-set-status"
 export GREP_COLOR="never"
 
 # Convert HELM_BIN and HELM_PLUGIN_DIR to unix if cygpath is

--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -93,7 +93,7 @@ getDownloadURL() {
   fi
 }
 
-# Temporary dir.
+# Temporary dir
 mkTempDir() {
   HELM_TMP="$(mktemp -d -t "${PROJECT_NAME}-XXXXXX")"
 }

--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -138,7 +138,7 @@ exit_trap() {
 	rmTempDir
 	if [ "$result" != "0" ]; then
 		echo "Failed to install $PROJECT_NAME"
-		printf "\tFor support, go to https://github.com/${PROJECT_GH}.\n"
+		printf "\tFor support, go to https://github.com/%s.\n" "$PROJECT_GH"
 	fi
 	exit $result
 }

--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -12,8 +12,8 @@ export GREP_COLOR="never"
 # need a Unix path
 
 if command -v cygpath >/dev/null 2>&1; then
-  HELM_BIN="$(cygpath -u "${HELM_BIN}")"
-  HELM_PLUGIN_DIR="$(cygpath -u "${HELM_PLUGIN_DIR}")"
+	HELM_BIN="$(cygpath -u "${HELM_BIN}")"
+	HELM_PLUGIN_DIR="$(cygpath -u "${HELM_PLUGIN_DIR}")"
 fi
 
 [ -z "$HELM_BIN" ] && HELM_BIN=$(command -v helm)
@@ -25,122 +25,122 @@ mkdir -p "$HELM_HOME"
 : "${HELM_PLUGIN_DIR:="$HELM_HOME/plugins/$PROJECT_NAME"}"
 
 if [ "$SKIP_BIN_INSTALL" = "1" ]; then
-  echo "Skipping binary install"
-  exit
+	echo "Skipping binary install"
+	exit
 fi
 
 # which mode is the common installer script running in
 SCRIPT_MODE="install"
 if [ "$1" = "-u" ]; then
-  SCRIPT_MODE="update"
+	SCRIPT_MODE="update"
 fi
 
 # initArch discovers the architecture for this system.
 initArch() {
-  ARCH=$(uname -m)
-  case $ARCH in
-  armv5*) ARCH="armv5" ;;
-  armv6*) ARCH="armv6" ;;
-  armv7*) ARCH="armv7" ;;
-  aarch64) ARCH="arm64" ;;
-  x86) ARCH="386" ;;
-  x86_64) ARCH="amd64" ;;
-  i686) ARCH="386" ;;
-  i386) ARCH="386" ;;
-  esac
+	ARCH=$(uname -m)
+	case $ARCH in
+	armv5*) ARCH="armv5" ;;
+	armv6*) ARCH="armv6" ;;
+	armv7*) ARCH="armv7" ;;
+	aarch64) ARCH="arm64" ;;
+	x86) ARCH="386" ;;
+	x86_64) ARCH="amd64" ;;
+	i686) ARCH="386" ;;
+	i386) ARCH="386" ;;
+	esac
 }
 
 # initOS discovers the operating system for this system.
 initOS() {
-  OS=$(uname -s)
+	OS=$(uname -s)
 
-  case "$OS" in
-  Windows_NT) OS='windows' ;;
-  # Msys support
-  MSYS*) OS='windows' ;;
-  # Minimalist GNU for Windows
-  MINGW*) OS='windows' ;;
-  CYGWIN*) OS='windows' ;;
-  Darwin) OS='macos' ;;
-  Linux) OS='linux' ;;
-  esac
+	case "$OS" in
+	Windows_NT) OS='windows' ;;
+	# Msys support
+	MSYS*) OS='windows' ;;
+	# Minimalist GNU for Windows
+	MINGW*) OS='windows' ;;
+	CYGWIN*) OS='windows' ;;
+	Darwin) OS='macos' ;;
+	Linux) OS='linux' ;;
+	esac
 }
 
 # verifySupported checks that the os/arch combination is supported for
 # binary builds.
 verifySupported() {
-  supported="linux-amd64\nlinux-arm64\nfreebsd-amd64\nmacos-amd64\nmacos-arm64\nwindows-amd64"
-  if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
-    echo "No prebuild binary for ${OS}-${ARCH}."
-    exit 1
-  fi
+	supported="linux-amd64\nlinux-arm64\nfreebsd-amd64\nmacos-amd64\nmacos-arm64\nwindows-amd64"
+	if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
+		echo "No prebuild binary for ${OS}-${ARCH}."
+		exit 1
+	fi
 
-  if
-    ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1
-  then
-    echo "Either curl or wget is required"
-    exit 1
-  fi
+	if
+		! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1
+	then
+		echo "Either curl or wget is required"
+		exit 1
+	fi
 }
 
 # getDownloadURL checks the latest available version.
 getDownloadURL() {
-  version=$(git -C "$HELM_PLUGIN_DIR" describe --tags --exact-match 2>/dev/null || :)
-  if [ "$SCRIPT_MODE" = "install" ] && [ -n "$version" ]; then
-    DOWNLOAD_URL="https://github.com/$PROJECT_GH/releases/download/$version/$PROJECT_NAME-$OS-$ARCH.tgz"
-  else
-    DOWNLOAD_URL="https://github.com/$PROJECT_GH/releases/latest/download/$PROJECT_NAME-$OS-$ARCH.tgz"
-  fi
+	version=$(git -C "$HELM_PLUGIN_DIR" describe --tags --exact-match 2>/dev/null || :)
+	if [ "$SCRIPT_MODE" = "install" ] && [ -n "$version" ]; then
+		DOWNLOAD_URL="https://github.com/$PROJECT_GH/releases/download/$version/$PROJECT_NAME-$OS-$ARCH.tgz"
+	else
+		DOWNLOAD_URL="https://github.com/$PROJECT_GH/releases/latest/download/$PROJECT_NAME-$OS-$ARCH.tgz"
+	fi
 }
 
 # Temporary dir
 mkTempDir() {
-  HELM_TMP="$(mktemp -d -t "${PROJECT_NAME}-XXXXXX")"
+	HELM_TMP="$(mktemp -d -t "${PROJECT_NAME}-XXXXXX")"
 }
 rmTempDir() {
-  if [ -d "${HELM_TMP:-/tmp/helm-set-status-tmp}" ]; then
-    rm -rf "${HELM_TMP:-/tmp/helm-set-status-tmp}"
-  fi
+	if [ -d "${HELM_TMP:-/tmp/helm-set-status-tmp}" ]; then
+		rm -rf "${HELM_TMP:-/tmp/helm-set-status-tmp}"
+	fi
 }
 
 # downloadFile downloads the latest binary package and also the checksum
 # for that binary.
 downloadFile() {
-  PLUGIN_TMP_FILE="${HELM_TMP}/${PROJECT_NAME}.tgz"
-  echo "Downloading $DOWNLOAD_URL"
-  if
-    command -v curl >/dev/null 2>&1
-  then
-    curl -sSf -L "$DOWNLOAD_URL" >"$PLUGIN_TMP_FILE"
-  elif
-    command -v wget >/dev/null 2>&1
-  then
-    wget -q -O - "$DOWNLOAD_URL" >"$PLUGIN_TMP_FILE"
-  fi
+	PLUGIN_TMP_FILE="${HELM_TMP}/${PROJECT_NAME}.tgz"
+	echo "Downloading $DOWNLOAD_URL"
+	if
+		command -v curl >/dev/null 2>&1
+	then
+		curl -sSf -L "$DOWNLOAD_URL" >"$PLUGIN_TMP_FILE"
+	elif
+		command -v wget >/dev/null 2>&1
+	then
+		wget -q -O - "$DOWNLOAD_URL" >"$PLUGIN_TMP_FILE"
+	fi
 }
 
 # installFile verifies the SHA256 for the file, then unpacks and
 # installs it.
 installFile() {
-  tar xzf "$PLUGIN_TMP_FILE" -C "$HELM_TMP"
-  HELM_TMP_BIN="$HELM_TMP/$PROJECT_NAME/bin/$PROJECT_NAME"
-  if [ "${OS}" = "windows" ]; then
-    HELM_TMP_BIN="$HELM_TMP_BIN.exe"
-  fi
-  echo "Preparing to install into ${HELM_PLUGIN_DIR}"
-  mkdir -p "$HELM_PLUGIN_DIR/bin"
-  cp "$HELM_TMP_BIN" "$HELM_PLUGIN_DIR/bin"
+	tar xzf "$PLUGIN_TMP_FILE" -C "$HELM_TMP"
+	HELM_TMP_BIN="$HELM_TMP/$PROJECT_NAME/bin/$PROJECT_NAME"
+	if [ "${OS}" = "windows" ]; then
+		HELM_TMP_BIN="$HELM_TMP_BIN.exe"
+	fi
+	echo "Preparing to install into ${HELM_PLUGIN_DIR}"
+	mkdir -p "$HELM_PLUGIN_DIR/bin"
+	cp "$HELM_TMP_BIN" "$HELM_PLUGIN_DIR/bin"
 }
 
 # exit_trap is executed if on exit (error or not).
 exit_trap() {
-  result=$?
-  rmTempDir
-  if [ "$result" != "0" ]; then
-    echo "Failed to install $PROJECT_NAME"
-    printf "\tFor support, go to https://github.com/${PROJECT_GH}.\n"
-  fi
-  exit $result
+	result=$?
+	rmTempDir
+	if [ "$result" != "0" ]; then
+		echo "Failed to install $PROJECT_NAME"
+		printf "\tFor support, go to https://github.com/${PROJECT_GH}.\n"
+	fi
+	exit $result
 }
 
 # Execution

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,8 +3,8 @@ set -e
 
 # == would end up with: scripts/release.sh: 5: [: v3.8.1: unexpected operator
 if [ "$1" = "" ]; then
-  echo usage: "$0 VERSION"
-  exit 1
+	echo usage: "$0 VERSION"
+	exit 1
 fi
 
 git tag $1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -e
+
+# == would end up with: scripts/release.sh: 5: [: v3.8.1: unexpected operator
+if [ "$1" = "" ]; then
+  echo usage: "$0 VERSION"
+  exit 1
+fi
+
+git tag $1
+git push origin $1
+gh release create $1 --draft --generate-notes --title "$1" release/*.tgz

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,6 +7,6 @@ if [ "$1" = "" ]; then
 	exit 1
 fi
 
-git tag $1
-git push origin $1
-gh release create $1 --draft --generate-notes --title "$1" release/*.tgz
+git tag "$1"
+git push origin "$1"
+gh release create "$1" --draft --generate-notes --title "$1" release/*.tgz

--- a/scripts/update-gofmt.sh
+++ b/scripts/update-gofmt.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# script credits : https://github.com/infracloudio/botkube
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename '*/vendor/*' \
+      \) -prune \
+    \) -name '*.go'
+}
+
+find_files | xargs gofmt -w -s

--- a/scripts/update-gofmt.sh
+++ b/scripts/update-gofmt.sh
@@ -6,11 +6,11 @@ set -o nounset
 set -o pipefail
 
 find_files() {
-  find . -not \( \
-      \( \
-        -wholename '*/vendor/*' \
-      \) -prune \
-    \) -name '*.go'
+	find . -not \( \
+		\( \
+		-wholename '*/vendor/*' \
+		\) -prune \
+		\) -name '*.go'
 }
 
 find_files | xargs gofmt -w -s

--- a/scripts/verify-gofmt.sh
+++ b/scripts/verify-gofmt.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# script credits : https://github.com/infracloudio/botkube
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename '*/vendor/*' \
+      \) -prune \
+    \) -name '*.go'
+}
+
+bad_files=$(find_files | xargs gofmt -d -s 2>&1)
+if [[ -n "${bad_files}" ]]; then
+  echo "${bad_files}" >&2
+  echo >&2
+  echo "Run ./hack/update-gofmt.sh" >&2
+  exit 1
+fi

--- a/scripts/verify-gofmt.sh
+++ b/scripts/verify-gofmt.sh
@@ -6,17 +6,17 @@ set -o nounset
 set -o pipefail
 
 find_files() {
-  find . -not \( \
-      \( \
-        -wholename '*/vendor/*' \
-      \) -prune \
-    \) -name '*.go'
+	find . -not \( \
+		\( \
+		-wholename '*/vendor/*' \
+		\) -prune \
+		\) -name '*.go'
 }
 
 bad_files=$(find_files | xargs gofmt -d -s 2>&1)
 if [[ -n "${bad_files}" ]]; then
-  echo "${bad_files}" >&2
-  echo >&2
-  echo "Run ./hack/update-gofmt.sh" >&2
-  exit 1
+	echo "${bad_files}" >&2
+	echo >&2
+	echo "Run ./hack/update-gofmt.sh" >&2
+	exit 1
 fi

--- a/scripts/verify-govet.sh
+++ b/scripts/verify-govet.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# script credits : https://github.com/infracloudio/botkube
+
+set -x
+
+go vet ./cmd/...

--- a/scripts/verify-staticcheck.sh
+++ b/scripts/verify-staticcheck.sh
@@ -5,15 +5,15 @@ set -o nounset
 set -o pipefail
 
 find_packages() {
-  find . -not \( \
-      \( \
-        -wholename '*/vendor/*' \
-      \) -prune \
-    \) -name '*.go' -exec dirname '{}' ';' | sort -u
+	find . -not \( \
+		\( \
+		-wholename '*/vendor/*' \
+		\) -prune \
+		\) -name '*.go' -exec dirname '{}' ';' | sort -u
 }
 
 errors="$(find_packages | xargs -I@ bash -c "staticcheck @")"
 if [[ -n "${errors}" ]]; then
-  echo "${errors}"
-  exit 1
+	echo "${errors}"
+	exit 1
 fi

--- a/scripts/verify-staticcheck.sh
+++ b/scripts/verify-staticcheck.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# script credits : https://github.com/infracloudio/botkube
+
+set -o nounset
+set -o pipefail
+
+find_packages() {
+  find . -not \( \
+      \( \
+        -wholename '*/vendor/*' \
+      \) -prune \
+    \) -name '*.go' -exec dirname '{}' ';' | sort -u
+}
+
+errors="$(find_packages | xargs -I@ bash -c "staticcheck @")"
+if [[ -n "${errors}" ]]; then
+  echo "${errors}"
+  exit 1
+fi

--- a/testdata/Dockerfile.install
+++ b/testdata/Dockerfile.install
@@ -1,0 +1,36 @@
+FROM alpine/helm:2.16.9
+
+ADD . /workspace
+
+WORKDIR /workspace
+
+RUN helm init -c
+RUN helm plugin install .
+RUN helm version -c
+
+FROM alpine/helm:3.2.4
+
+ADD . /workspace
+
+WORKDIR /workspace
+
+RUN helm plugin install .
+RUN helm version -c
+
+FROM ubuntu:focal
+
+ADD . /workspace
+
+WORKDIR /workspace
+
+# See "From Apt (Debian/Ubuntu)" at https://helm.sh/docs/intro/install/
+RUN apt-get update && \
+    apt-get install curl && \
+    curl https://helm.baltorepo.com/organization/signing.asc | sudo apt-key add - && \
+    apt-get install apt-transport-https --yes && \
+    echo "deb https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list && \
+    apt-get update && \
+    apt-get install helm
+
+RUN helm plugin install .
+RUN helm version -c

--- a/testdata/Dockerfile.install
+++ b/testdata/Dockerfile.install
@@ -25,12 +25,8 @@ WORKDIR /workspace
 
 # See "From Apt (Debian/Ubuntu)" at https://helm.sh/docs/intro/install/
 RUN apt-get update && \
-    apt-get install curl && \
-    curl https://helm.baltorepo.com/organization/signing.asc | sudo apt-key add - && \
-    apt-get install apt-transport-https --yes && \
-    echo "deb https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list && \
-    apt-get update && \
-    apt-get install helm
+    apt-get install -y curl && \
+    curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
 RUN helm plugin install .
 RUN helm version -c


### PR DESCRIPTION
This PR includes a number of fixes + enhancements all centered around making

`helm plugin install <repo>` functional and more robust.

Changes Included:
- Github actions for build + testing + compilation of release assets. Whenever a new release/tag is created, goreleaser will build the appropriate static libraries for all of the different architectures/operating systems.

- Tests the plugin install on all platforms using github actions

- Linting support for both golang and shell scripts to increase quality

- Enhancements to the local development makefile including a manual release process + dist packaging if actions based goreleaser is not desirable.